### PR TITLE
修复log时间类型默认值时显示错误问题

### DIFF
--- a/LiveSystem/util/util_log.h
+++ b/LiveSystem/util/util_log.h
@@ -228,7 +228,7 @@ namespace Tools {
                 //当前从开始到现在的时间戳
                 std::string timeStampStr = std::to_string(getCurrentMillisecond());
                 if(timeType == "NULL"){
-                    std::string timeType = getTimeType();
+                    timeType = getTimeType();
                 } 
                 logTxtInDic(logType,which,timeStampStr,timeType,detail);
                 // if(logType=="RGB_Push"){


### PR DESCRIPTION
###  修复之前，log信息
{"LogType": "Net_Produce", "Which": "P_frame", "AlgoTime": "1679388571615", "TimeType": **"NULL"**, "Detail": "2"}
### 修复之后
{"LogType": "Net_Produce", "Which": "P_frame", "AlgoTime": "1679388571615", "TimeType": **"ms"**, "Detail": "2"}
### 区别
注意TimeType的类型
### 原因
创建了一个与默认参数同名的局部变量，在传递时，使用的是默认参数。
局部函数作用域原因